### PR TITLE
add pyqt to conda_env

### DIFF
--- a/conda_env.yaml
+++ b/conda_env.yaml
@@ -8,3 +8,4 @@ dependencies:
   - swig
   - sphinx
   - sphinx_rtd_theme
+  - pyqt


### PR DESCRIPTION
Add pyqt to conda_env, which is a dependency for vispy.