### PR TITLE
Option to load crazyflies.yaml from string or alternate path.

### DIFF
--- a/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyflie.py
+++ b/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyflie.py
@@ -37,14 +37,14 @@ class TimeHelper:
         rospy.sleep(duration)
 
     def sleepForRate(self, rateHz):
-	"""Sleeps so that, if called in a loop, executes at specified rate."""
+        """Sleeps so that, if called in a loop, executes at specified rate."""
         if self.rosRate is None or self.rateHz != rateHz:
             self.rosRate = rospy.Rate(rateHz)
             self.rateHz = rateHz
-        self.rate.sleep()
+        self.rosRate.sleep()
 
     def isShutdown(self):
-	"""Returns true if the script should abort, e.g. from Ctrl-C."""
+        """Returns true if the script should abort, e.g. from Ctrl-C."""
         return rospy.is_shutdown()
 
 
@@ -445,9 +445,15 @@ class CrazyflieServer:
         crazyfliesById (Dict[int, Crazyflie]): Index to the same Crazyflie
             objects by their ID number (last byte of radio address).
     """
-    def __init__(self):
-        """Constructor. Waits for all ROS services before returning."""
+    def __init__(self, crazyflies_yaml="../launch/crazyflies.yaml"):
+        """Initialize the server. Waits for all ROS services before returning.
 
+        Args:
+            timeHelper (TimeHelper): TimeHelper instance.
+            crazyflies_yaml (str): If ends in ".yaml", interpret as a path and load
+                from file. Otherwise, interpret as YAML string and parse
+                directly from string.
+        """
         rospy.init_node("CrazyflieAPI", anonymous=False)
         rospy.wait_for_service("/emergency")
         self.emergencyService = rospy.ServiceProxy("/emergency", Empty)
@@ -464,8 +470,11 @@ class CrazyflieServer:
         rospy.wait_for_service("/update_params")
         self.updateParamsService = rospy.ServiceProxy("/update_params", UpdateParams)
 
-        with open("../launch/crazyflies.yaml", 'r') as ymlfile:
-            cfg = yaml.load(ymlfile)
+        if crazyflies_yaml.endswith(".yaml"):
+            with open(crazyflies_yaml, 'r') as ymlfile:
+                cfg = yaml.load(ymlfile)
+        else:
+            cfg = yaml.load(crazyflies_yaml)
 
         self.tf = TransformListener()
 

--- a/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyflieSim.py
+++ b/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyflieSim.py
@@ -219,9 +219,20 @@ class Crazyflie:
 
 
 class CrazyflieServer:
-    def __init__(self, timeHelper):
-        with open("../launch/crazyflies.yaml", 'r') as ymlfile:
-            cfg = yaml.load(ymlfile)
+    def __init__(self, timeHelper, crazyflies_yaml="../launch/crazyflies.yaml"):
+        """Initialize the server.
+
+        Args:
+            timeHelper (TimeHelper): TimeHelper instance.
+            crazyflies_yaml (str): If ends in ".yaml", interpret as a path and load
+                from file. Otherwise, interpret as YAML string and parse
+                directly from string.
+        """
+        if crazyflies_yaml.endswith(".yaml"):
+            with open(crazyflies_yaml, 'r') as ymlfile:
+                cfg = yaml.load(ymlfile)
+        else:
+            cfg = yaml.load(crazyflies_yaml)
 
         self.crazyflies = []
         self.crazyfliesById = dict()

--- a/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyswarm.py
+++ b/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyswarm.py
@@ -16,17 +16,22 @@ def build_argparser():
 
 
 class Crazyswarm:
-    def __init__(self):
+    def __init__(self, crazyflies_yaml=None):
         parser = build_argparser()
         args, unknown = parser.parse_known_args()
+
+        if crazyflies_yaml is None:
+            crazyflies_yaml = "../launch/crazyflies.yaml"
+        if crazyflies_yaml.endswith(".yaml"):
+            crazyflies_yaml = open(crazyflies_yaml, 'r').read()
 
         if args.sim:
             import crazyflieSim
             self.timeHelper = crazyflieSim.TimeHelper(args.vis, args.dt, args.writecsv)
-            self.allcfs = crazyflieSim.CrazyflieServer(self.timeHelper)
+            self.allcfs = crazyflieSim.CrazyflieServer(self.timeHelper, crazyflies_yaml)
         else:
             import crazyflie
-            self.allcfs = crazyflie.CrazyflieServer()
+            self.allcfs = crazyflie.CrazyflieServer(crazyflies_yaml)
             self.timeHelper = crazyflie.TimeHelper()
             if args.writecsv:
                 print("WARNING: writecsv argument ignored! This is only available in simulation.")

--- a/ros_ws/src/crazyswarm/scripts/testYamlString.py
+++ b/ros_ws/src/crazyswarm/scripts/testYamlString.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import numpy as np
+from pycrazyswarm import *
+
+Z = 1.0
+
+crazyflies_yaml = """
+crazyflies:
+- channel: 100
+  id: 1
+  initialPosition: [1.0, 0.0, 0.0]
+- channel: 100
+  id: 10
+  initialPosition: [0.0, -1.0, 0.0]
+"""
+
+if __name__ == "__main__":
+    swarm = Crazyswarm(launch_yaml=crazyflies_yaml)
+    timeHelper = swarm.timeHelper
+    cfs = swarm.allcfs.crazyflies
+    byId = swarm.allcfs.crazyfliesById
+
+    assert len(cfs) == 2
+    cf1 = byId[1]
+    assert np.all(cf1.initialPosition == [1.0, 0.0, 0.0])
+
+    cf10 = byId[10]
+    assert np.all(cf10.initialPosition == [0.0, -1.0, 0.0])
+
+    print("Loaded YAML from string OK.")

--- a/ros_ws/src/crazyswarm/scripts/testYamlString.py
+++ b/ros_ws/src/crazyswarm/scripts/testYamlString.py
@@ -16,7 +16,7 @@ crazyflies:
 """
 
 if __name__ == "__main__":
-    swarm = Crazyswarm(launch_yaml=crazyflies_yaml)
+    swarm = Crazyswarm(crazyflies_yaml=crazyflies_yaml)
     timeHelper = swarm.timeHelper
     cfs = swarm.allcfs.crazyflies
     byId = swarm.allcfs.crazyfliesById


### PR DESCRIPTION
Until now, the set of robots in a pycrazyswarm script is always
determined by ros_ws/src/crazyswarm/launch/crazyflies.yaml. This
couples the result of the script to the state of the executing machine.
If we want to add more automated testing in the future, it should be
possible to write a pycrazyswarm script that runs deterministically
without the cumbersome process of writing .yaml to disk.