### PR TITLE
Add pose log topic.

### DIFF
--- a/ros_ws/src/crazyswarm/src/crazyswarm_server.cpp
+++ b/ros_ws/src/crazyswarm/src/crazyswarm_server.cpp
@@ -686,7 +686,6 @@ private:
   }
 
   void onConsole(const char* msg) {
-    std::cout << "bla " << msg << std::endl;
     m_messageBuffer += msg;
     size_t pos = m_messageBuffer.find('\n');
     if (pos != std::string::npos) {


### PR DESCRIPTION
When enabled, /cf<id>/pose is published with the internal state estimate
from the on-board EKF. This is useful for on-board state estimators
(flow deck, lighthouse, LPS).