### PR TITLE
Fix issue where Crazyflie debug output was not fully printed.

### DIFF
--- a/ros_ws/src/crazyswarm/src/crazyswarm_server.cpp
+++ b/ros_ws/src/crazyswarm/src/crazyswarm_server.cpp
@@ -1114,15 +1114,6 @@ private:
       }
     }
 
-    // Turn all CFs on
-    for (const auto& config : cfConfigs) {
-      Crazyflie cf(config.uri);
-      cf.syson();
-      for (size_t i = 0; i < 50; ++i) {
-        cf.sendPing();
-      }
-    }
-
     ros::NodeHandle nl("~");
     bool enableLogging;
     bool enableParameters;


### PR DESCRIPTION
The current code temporarily instantiated Crazyflie objects to call
sysOn. This had two major issues:
 1. OnConsole messages received during this period are not logged using
    ROS_INFO. This essentially prevents the Crazyswarm from printing
    useful start-up sequence information (e.g., failures during sensor
    or deck initialization.)
 2. This method never worked correctly for more than 5 CFs. Instead, the
    recommended use-case always has been to reboot selected CFs using
    chooser.py before launching the crazyswarm_server.

Because of 2., the safest (and easiest) way to fix 1. is to remove the
code accordingly.