### PR TITLE
Port CI from Travis to Github Actions (#222)

### DIFF
--- a/.github/workflows/ci-ros.yml
+++ b/.github/workflows/ci-ros.yml
@@ -1,0 +1,64 @@
+name: Crazyswarm ROS CI
+
+on: [push, pull_request]
+
+env:
+  ROS_CI_DESKTOP: "`lsb_release -cs`"  # gives Ubuntu name, e.g. [precise|trusty|...]
+  ROS_PARALLEL_JOBS: "-j8 -l6"
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-16.04
+            ros: kinetic
+          - os: ubuntu-18.04
+            ros: melodic
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      run: |
+        # Install non-ROS system dependencies.
+        sudo apt install -y swig libpython-dev python-numpy python-yaml python-matplotlib python-pytest
+        # Install firmware cross-compiler and hardware driver dependencies.
+        sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
+        sudo apt-get update
+        sudo apt install -y gcc-arm-embedded libusb-1.0-0-dev sdcc
+        # Set the python path manually to include /usr/-/python2.7/dist-packages
+        # as this is where apt-get installs python packages.
+        PYTHONPATH=$PYTHONPATH:/usr/lib/python2.7/dist-packages:/usr/local/lib/python2.7/dist-packages
+
+
+    - name: Install ROS
+      run: |
+        sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+        sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+        sudo apt-get update -qq
+        sudo apt-get install dpkg
+        sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-${{ matrix.ros }}-ros-base
+        source /opt/ros/${{ matrix.ros }}/setup.bash
+        # Prepare rosdep to install dependencies.
+        sudo rosdep init
+        rosdep update
+        sudo apt install -y ros-${{ matrix.ros }}-vrpn ros-${{ matrix.ros }}-tf ros-${{ matrix.ros }}-tf-conversions
+        # Install non-ROS dependencies that only seem to install correctly
+        # in the post-ROS system state. (TODO: figure out why.)
+        sudo apt install -y libpcl-dev
+
+    - name: Build
+      run: |
+        source /opt/ros/${{ matrix.ros }}/setup.bash
+        ./build.sh
+
+    - name: Test
+      run: |
+        cd ros_ws/src/crazyswarm/scripts
+        python -m pytest

--- a/.github/workflows/ci-ros.yml
+++ b/.github/workflows/ci-ros.yml
@@ -24,34 +24,19 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Install ROS
+      uses: ros-tooling/setup-ros@0.0.16
+      with:
+        required-ros-distributions: ${{ matrix.ros }}
+
     - name: Install Dependencies
       run: |
-        # Install non-ROS system dependencies.
+        sudo apt install -y ros-${{ matrix.ros }}-vrpn ros-${{ matrix.ros }}-tf ros-${{ matrix.ros }}-tf-conversions
+        sudo apt install -y libpcl-dev
         sudo apt install -y swig libpython-dev python-numpy python-yaml python-matplotlib python-pytest
-        # Install firmware cross-compiler and hardware driver dependencies.
         sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
         sudo apt-get update
         sudo apt install -y gcc-arm-embedded libusb-1.0-0-dev sdcc
-        # Set the python path manually to include /usr/-/python2.7/dist-packages
-        # as this is where apt-get installs python packages.
-        PYTHONPATH=$PYTHONPATH:/usr/lib/python2.7/dist-packages:/usr/local/lib/python2.7/dist-packages
-
-
-    - name: Install ROS
-      run: |
-        sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
-        sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
-        sudo apt-get update -qq
-        sudo apt-get install dpkg
-        sudo apt-get install -y python-catkin-pkg python-rosdep python-wstool ros-${{ matrix.ros }}-ros-base
-        source /opt/ros/${{ matrix.ros }}/setup.bash
-        # Prepare rosdep to install dependencies.
-        sudo rosdep init
-        rosdep update
-        sudo apt install -y ros-${{ matrix.ros }}-vrpn ros-${{ matrix.ros }}-tf ros-${{ matrix.ros }}-tf-conversions
-        # Install non-ROS dependencies that only seem to install correctly
-        # in the post-ROS system state. (TODO: figure out why.)
-        sudo apt install -y libpcl-dev
 
     - name: Build
       run: |

--- a/.github/workflows/ci-simonly.yml
+++ b/.github/workflows/ci-simonly.yml
@@ -1,4 +1,4 @@
-name: Crazyswarm Sim-Only Conda CI
+name: Sim-Only Conda CI
 
 on: [push, pull_request]
 

--- a/.github/workflows/ci-simonly.yml
+++ b/.github/workflows/ci-simonly.yml
@@ -1,0 +1,33 @@
+name: Crazyswarm Sim-Only Conda CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Conda
+      uses: goanpeca/setup-miniconda@v1
+      with:
+        environment-file: conda_env.yaml
+        activate-environment: crazyswarm
+
+    - name: Build
+      shell: bash -l {0}
+      run: |
+        ./buildSimOnly.sh
+
+    - name: Test
+      shell: bash -l {0}
+      run: |
+        cd ros_ws/src/crazyswarm/scripts
+        python -m pytest


### PR DESCRIPTION
Recreate our CI workflows in Github Actions.

As mentioned in #222, Github stopped showing our "green checkmarks" a while back. Even worse, at some point we started getting "unauthenticated packages" errors (like [this](https://travis-ci.org/github/USC-ACTLab/crazyswarm/jobs/708110502)) non-deterministically.