### PR TITLE
Remove dependency to crazyflie_ros by adding msg/srv directly here.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,6 @@
 [submodule "ros_ws/src/externalDependencies/libmotioncapture"]
 	path = ros_ws/src/externalDependencies/libmotioncapture
 	url = https://github.com/USC-ACTLab/libmotioncapture.git
-[submodule "ros_ws/src/crazyflie_ros"]
-	path = ros_ws/src/crazyflie_ros
-	url = https://github.com/whoenig/crazyflie_ros.git
+[submodule "ros_ws/src/crazyflie_tools"]
+	path = ros_ws/src/crazyflie_tools
+	url = https://github.com/whoenig/crazyflie_tools.git

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ ROOT=$PWD
 git submodule init
 git submodule update
 
-cd ros_ws/src/crazyflie_ros/
+cd ros_ws/src/crazyflie_tools/
 git submodule init
 git submodule update
 cd $ROOT

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -361,5 +361,4 @@ autodoc_mock_imports = [
     'std_srvs',
     'tf',
     'tf_conversions',
-    'crazyflie_driver',
 ]

--- a/docs/howto/streaming_setpoint.rst
+++ b/docs/howto/streaming_setpoint.rst
@@ -235,7 +235,7 @@ which are designed specifically for streaming "fire and forget" data.
 Complex setpoint types may require defining a new ROS message type.
 It is always preferable to use standard types if an appropriate type exists.
 For the full quadrotor state, we define a new message
-in `crazyflie_driver/msg/FullState.msg <https://github.com/whoenig/crazyflie_ros/blob/master/crazyflie_driver/msg/FullState.msg>`_:
+in `crazyswarm/msg/FullState.msg <https://github.com/USC-ACTLab/crazyswarm/tree/master/ros_ws/src/crazyswarm/msg/FullState.msg>`_:
 
 .. code-block:: none
 
@@ -264,7 +264,7 @@ with ``...``:
 	public:
 	...
 		void cmdFullStateSetpoint(
-			const crazyflie_driver::FullState::ConstPtr& msg)
+			const crazyswarm::FullState::ConstPtr& msg)
 		{
 			if (!m_isEmergency) {
 				float x = msg->pose.position.x;
@@ -313,7 +313,7 @@ the ROS publisher object and converting ``numpy`` types into ROS types:
 
 .. code-block:: python
 
-	from crazyflie_driver.msg import ..., FullState
+	from crazyswarm.msg import ..., FullState
 
 	class Crazyflie:
 

--- a/docs/howto/streaming_setpoint.rst
+++ b/docs/howto/streaming_setpoint.rst
@@ -357,7 +357,7 @@ rather than waiting for the packet to actually be sent on the radio.
 .. admonition:: Note: Why so many layers?
 
 	We have modified three layers on the PC side of things to add our new
-	setpoint type: ``crazyflie_cpp``, ``crazyflie_ros``, and ``pycrazyswarm``.
+	setpoint type: ``crazyflie_cpp``, ``crazyswarm``, and ``pycrazyswarm``.
 	We wrote a lot of boilerplate code to copy the same data from
 	NumPy types, to ROS types, to C++ function arguments, and finally to
 	a CRTP binary protocol struct. To understand what we gained with this
@@ -367,7 +367,7 @@ rather than waiting for the packet to actually be sent on the radio.
 		1. ``crazyflie_cpp`` is the only layer that needs to understand
 		   the radio protocol and how to control the Crazyradio via USB.
 
-		2. ``crazyflie_ros`` handles all the concurrency.
+		2. ``crazyswarm`` handles all the concurrency.
 		   It performs the M:N multiplexing of multiple Crazyflies
 		   onto multiple Crazyradios, deals with resending and ACKs
 		   in reliable communiation modes (not discussed in this tutorial),
@@ -379,8 +379,8 @@ rather than waiting for the packet to actually be sent on the radio.
 		   and versions. We can develop in the simulator on MacOS and other
 		   Linuxes.
 	
-	It is also worth mentioning that ``crazyflie_cpp`` and ``crazyflie_ros``
-	are both standalone projects that can be used outside the Crazyswarm setting.
+	It is also worth mentioning that ``crazyflie_cpp`` is a standalone 
+	project that can be used outside the Crazyswarm setting.
 
 
 Firmware CRTP parsing

--- a/ros_ws/src/crazyswarm/CMakeLists.txt
+++ b/ros_ws/src/crazyswarm/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   tf
   crazyflie_cpp
-  crazyflie_driver
   libobjecttracker
   libmotioncapture
   tf_conversions
@@ -51,19 +50,37 @@ find_package(PCL REQUIRED)
 ##   * uncomment the generate_messages entry below
 ##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
 
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
 ## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
+add_service_files(
+  FILES
+  GoTo.srv
+  Land.srv
+  NotifySetpointsStop.srv
+  SetGroupMask.srv
+  StartTrajectory.srv
+  Stop.srv
+  Takeoff.srv
+  UpdateParams.srv
+  UploadTrajectory.srv
+)
+
+add_message_files(
+  FILES
+  LogBlock.msg
+  GenericLogData.msg
+  FullState.msg
+  VelocityWorld.msg
+  TrajectoryPolynomialPiece.msg
+  Hover.msg
+  Position.msg
+)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+   std_msgs
+   geometry_msgs
+)
 
 ## Generate actions in the 'action' folder
 # add_action_files(
@@ -115,7 +132,6 @@ catkin_package(
     std_msgs
     tf
     crazyflie_cpp
-    crazyflie_driver
     # libobjecttracker
 #  DEPENDS system_lib
 )

--- a/ros_ws/src/crazyswarm/CMakeLists.txt
+++ b/ros_ws/src/crazyswarm/CMakeLists.txt
@@ -169,8 +169,6 @@ if (ENABLE_VRPN)
 endif()
 
 
-# message(${CMAKE_BINARY_DIR}/crazyflie_ros/externalDependencies/libobjecttracker)
-
 ## Declare a cpp executable
 add_executable(crazyswarm_server
   src/crazyswarm_server.cpp

--- a/ros_ws/src/crazyswarm/msg/FullState.msg
+++ b/ros_ws/src/crazyswarm/msg/FullState.msg
@@ -1,0 +1,4 @@
+Header header
+geometry_msgs/Pose pose
+geometry_msgs/Twist twist
+geometry_msgs/Vector3 acc

--- a/ros_ws/src/crazyswarm/msg/GenericLogData.msg
+++ b/ros_ws/src/crazyswarm/msg/GenericLogData.msg
@@ -1,0 +1,2 @@
+Header header
+float64[] values

--- a/ros_ws/src/crazyswarm/msg/Hover.msg
+++ b/ros_ws/src/crazyswarm/msg/Hover.msg
@@ -1,0 +1,5 @@
+Header header
+float32 vx
+float32 vy
+float32 yawrate
+float32 zDistance

--- a/ros_ws/src/crazyswarm/msg/LogBlock.msg
+++ b/ros_ws/src/crazyswarm/msg/LogBlock.msg
@@ -1,0 +1,3 @@
+string topic_name
+int16 frequency
+string[] variables

--- a/ros_ws/src/crazyswarm/msg/Position.msg
+++ b/ros_ws/src/crazyswarm/msg/Position.msg
@@ -1,0 +1,5 @@
+Header header
+float32 x
+float32 y
+float32 z
+float32 yaw

--- a/ros_ws/src/crazyswarm/msg/TrajectoryPolynomialPiece.msg
+++ b/ros_ws/src/crazyswarm/msg/TrajectoryPolynomialPiece.msg
@@ -1,0 +1,7 @@
+#
+
+float32[] poly_x
+float32[] poly_y
+float32[] poly_z
+float32[] poly_yaw
+duration duration

--- a/ros_ws/src/crazyswarm/msg/VelocityWorld.msg
+++ b/ros_ws/src/crazyswarm/msg/VelocityWorld.msg
@@ -1,0 +1,3 @@
+Header header
+geometry_msgs/Vector3 vel
+float32 yawRate

--- a/ros_ws/src/crazyswarm/package.xml
+++ b/ros_ws/src/crazyswarm/package.xml
@@ -19,7 +19,6 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>crazyflie_cpp</build_depend>
-  <build_depend>crazyflie_driver</build_depend>
   <build_depend>libobjecttracker</build_depend>
   <build_depend>libmotioncapture</build_depend>
   <build_depend>tf_conversion</build_depend>
@@ -28,7 +27,6 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>crazyflie_cpp</run_depend>
-  <run_depend>crazyflie_driver</run_depend>
   <run_depend>libobjecttracker</run_depend>
   <run_depend>libmotioncapture</run_depend>
 

--- a/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyflie.py
+++ b/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyflie.py
@@ -9,8 +9,8 @@ import time
 import tf_conversions
 from std_srvs.srv import Empty
 import std_msgs
-from crazyflie_driver.srv import *
-from crazyflie_driver.msg import TrajectoryPolynomialPiece, FullState, Position, VelocityWorld
+from crazyswarm.srv import *
+from crazyswarm.msg import TrajectoryPolynomialPiece, FullState, Position, VelocityWorld
 from tf import TransformListener
 from .visualizer import visNull
 

--- a/ros_ws/src/crazyswarm/src/crazyswarm_server.cpp
+++ b/ros_ws/src/crazyswarm/src/crazyswarm_server.cpp
@@ -3,23 +3,22 @@
 #include <tf_conversions/tf_eigen.h>
 #include <ros/callback_queue.h>
 
-#include "crazyflie_driver/AddCrazyflie.h"
-#include "crazyflie_driver/LogBlock.h"
-#include "crazyflie_driver/GenericLogData.h"
-#include "crazyflie_driver/UpdateParams.h"
-#include "crazyflie_driver/UploadTrajectory.h"
-#include "crazyflie_driver/NotifySetpointsStop.h"
+#include "crazyswarm/LogBlock.h"
+#include "crazyswarm/GenericLogData.h"
+#include "crazyswarm/UpdateParams.h"
+#include "crazyswarm/UploadTrajectory.h"
+#include "crazyswarm/NotifySetpointsStop.h"
 #undef major
 #undef minor
-#include "crazyflie_driver/Hover.h"
-#include "crazyflie_driver/Takeoff.h"
-#include "crazyflie_driver/Land.h"
-#include "crazyflie_driver/GoTo.h"
-#include "crazyflie_driver/StartTrajectory.h"
-#include "crazyflie_driver/SetGroupMask.h"
-#include "crazyflie_driver/FullState.h"
-#include "crazyflie_driver/Position.h"
-#include "crazyflie_driver/VelocityWorld.h"
+#include "crazyswarm/Hover.h"
+#include "crazyswarm/Takeoff.h"
+#include "crazyswarm/Land.h"
+#include "crazyswarm/GoTo.h"
+#include "crazyswarm/StartTrajectory.h"
+#include "crazyswarm/SetGroupMask.h"
+#include "crazyswarm/FullState.h"
+#include "crazyswarm/Position.h"
+#include "crazyswarm/VelocityWorld.h"
 #include "std_srvs/Empty.h"
 #include <std_msgs/Empty.h>
 #include "geometry_msgs/Twist.h"
@@ -174,7 +173,7 @@ public:
     const std::string& worldFrame,
     int id,
     const std::string& type,
-    const std::vector<crazyflie_driver::LogBlock>& log_blocks,
+    const std::vector<crazyswarm::LogBlock>& log_blocks,
     ros::CallbackQueue& queue)
     : m_tf_prefix(tf_prefix)
     , m_cf(
@@ -225,7 +224,7 @@ public:
       m_logFile.open("logcf" + std::to_string(id) + ".csv");
       m_logFile << "time,";
       for (auto& logBlock : m_logBlocks) {
-        m_pubLogDataGeneric.push_back(n.advertise<crazyflie_driver::GenericLogData>(tf_prefix + "/" + logBlock.topic_name, 10));
+        m_pubLogDataGeneric.push_back(n.advertise<crazyswarm::GenericLogData>(tf_prefix + "/" + logBlock.topic_name, 10));
         for (const auto& variableName : logBlock.variables) {
           m_logFile << variableName << ",";
         }
@@ -317,8 +316,8 @@ public:
   }
 
   bool updateParams(
-    crazyflie_driver::UpdateParams::Request& req,
-    crazyflie_driver::UpdateParams::Response& res)
+    crazyswarm::UpdateParams::Request& req,
+    crazyswarm::UpdateParams::Response& res)
   {
     ROS_INFO("[%s] Update parameters", m_frame.c_str());
     m_cf.startSetParamRequest();
@@ -365,8 +364,8 @@ public:
 
 
   bool uploadTrajectory(
-    crazyflie_driver::UploadTrajectory::Request& req,
-    crazyflie_driver::UploadTrajectory::Response& res)
+    crazyswarm::UploadTrajectory::Request& req,
+    crazyswarm::UploadTrajectory::Response& res)
   {
     ROS_INFO("[%s] Upload trajectory", m_frame.c_str());
 
@@ -396,8 +395,8 @@ public:
   }
 
   bool startTrajectory(
-    crazyflie_driver::StartTrajectory::Request& req,
-    crazyflie_driver::StartTrajectory::Response& res)
+    crazyswarm::StartTrajectory::Request& req,
+    crazyswarm::StartTrajectory::Response& res)
   {
     ROS_INFO("[%s] Start trajectory", m_frame.c_str());
 
@@ -407,8 +406,8 @@ public:
   }
 
   bool notifySetpointsStop(
-    crazyflie_driver::NotifySetpointsStop::Request& req,
-    crazyflie_driver::NotifySetpointsStop::Response& res)
+    crazyswarm::NotifySetpointsStop::Request& req,
+    crazyswarm::NotifySetpointsStop::Response& res)
   {
     ROS_INFO_NAMED(m_tf_prefix, "NotifySetpointsStop requested");
     m_cf.notifySetpointsStop(req.remainValidMillisecs);
@@ -416,8 +415,8 @@ public:
   }
 
   bool takeoff(
-    crazyflie_driver::Takeoff::Request& req,
-    crazyflie_driver::Takeoff::Response& res)
+    crazyswarm::Takeoff::Request& req,
+    crazyswarm::Takeoff::Response& res)
   {
     ROS_INFO("[%s] Takeoff", m_frame.c_str());
 
@@ -427,8 +426,8 @@ public:
   }
 
   bool land(
-    crazyflie_driver::Land::Request& req,
-    crazyflie_driver::Land::Response& res)
+    crazyswarm::Land::Request& req,
+    crazyswarm::Land::Response& res)
   {
     ROS_INFO("[%s] Land", m_frame.c_str());
 
@@ -438,8 +437,8 @@ public:
   }
 
   bool goTo(
-    crazyflie_driver::GoTo::Request& req,
-    crazyflie_driver::GoTo::Response& res)
+    crazyswarm::GoTo::Request& req,
+    crazyswarm::GoTo::Response& res)
   {
     ROS_INFO("[%s] GoTo", m_frame.c_str());
 
@@ -449,8 +448,8 @@ public:
   }
 
   bool setGroupMask(
-    crazyflie_driver::SetGroupMask::Request& req,
-    crazyflie_driver::SetGroupMask::Response& res)
+    crazyswarm::SetGroupMask::Request& req,
+    crazyswarm::SetGroupMask::Response& res)
   {
     ROS_INFO("[%s] Set Group Mask", m_frame.c_str());
 
@@ -475,7 +474,7 @@ public:
   }
 
   void cmdPositionSetpoint(
-    const crazyflie_driver::Position::ConstPtr& msg)
+    const crazyswarm::Position::ConstPtr& msg)
   {
     // if(!m_isEmergency) {
       float x = msg->x;
@@ -489,7 +488,7 @@ public:
   }
 
   void cmdFullStateSetpoint(
-    const crazyflie_driver::FullState::ConstPtr& msg)
+    const crazyswarm::FullState::ConstPtr& msg)
   {
     //ROS_INFO("got a full state setpoint");
     // if (!m_isEmergency) {
@@ -522,7 +521,7 @@ public:
     // }
   }
 
-  void cmdHoverSetpoint(const crazyflie_driver::Hover::ConstPtr& msg){
+  void cmdHoverSetpoint(const crazyswarm::Hover::ConstPtr& msg){
      //ROS_INFO("got a hover setpoint");
       float vx = msg->vx;
       float vy = msg->vy;
@@ -534,7 +533,7 @@ public:
 
   }
   void cmdVelocityWorldSetpoint(
-    const crazyflie_driver::VelocityWorld::ConstPtr& msg)
+    const crazyswarm::VelocityWorld::ConstPtr& msg)
   {
     // ROS_INFO("got a velocity world setpoint");
     // if (!m_isEmergency) {
@@ -766,7 +765,7 @@ private:
 
     ros::Publisher* pub = reinterpret_cast<ros::Publisher*>(userData);
 
-    crazyflie_driver::GenericLogData msg;
+    crazyswarm::GenericLogData msg;
     msg.header.stamp = ros::Time(time_in_ms/1000.0);
     msg.values = *values;
 
@@ -807,7 +806,7 @@ private:
 
   ros::Subscriber m_subscribeCmdHover; // Hover vel subscriber
 
-  std::vector<crazyflie_driver::LogBlock> m_logBlocks;
+  std::vector<crazyswarm::LogBlock> m_logBlocks;
   std::vector<ros::Publisher> m_pubLogDataGeneric;
   std::vector<std::unique_ptr<LogBlockGeneric> > m_logBlocksGeneric;
 
@@ -841,7 +840,7 @@ public:
     int radio,
     int channel,
     bool useMotionCaptureObjectTracking,
-    const std::vector<crazyflie_driver::LogBlock>& logBlocks,
+    const std::vector<crazyswarm::LogBlock>& logBlocks,
     std::string interactiveObject,
     bool writeCSVs,
     bool sendPositionOnly
@@ -1159,7 +1158,7 @@ private:
   void readObjects(
     std::vector<libobjecttracker::Object>& objects,
     int channel,
-    const std::vector<crazyflie_driver::LogBlock>& logBlocks)
+    const std::vector<crazyswarm::LogBlock>& logBlocks)
   {
     // read CF config
     struct CFConfig
@@ -1234,7 +1233,7 @@ private:
     const std::string& worldFrame,
     int id,
     const std::string& type,
-    const std::vector<crazyflie_driver::LogBlock>& logBlocks)
+    const std::vector<crazyswarm::LogBlock>& logBlocks)
   {
     ROS_INFO("Adding CF: %s (%s, %s)...", tf_prefix.c_str(), uri.c_str(), frame.c_str());
     auto start = std::chrono::high_resolution_clock::now();
@@ -1288,8 +1287,8 @@ private:
     }
 
 
-    crazyflie_driver::UpdateParams::Request request;
-    crazyflie_driver::UpdateParams::Response response;
+    crazyswarm::UpdateParams::Request request;
+    crazyswarm::UpdateParams::Response response;
 
     for (auto& firmwareParams : firmwareParamsVec) {
       // ROS_ASSERT(firmwareParams.getType() == XmlRpc::XmlRpcValue::TypeArray);
@@ -1469,13 +1468,13 @@ public:
     nl.param("genericLogTopics", genericLogTopics, std::vector<std::string>());
     std::vector<int> genericLogTopicFrequencies;
     nl.param("genericLogTopicFrequencies", genericLogTopicFrequencies, std::vector<int>());
-    std::vector<crazyflie_driver::LogBlock> logBlocks;
+    std::vector<crazyswarm::LogBlock> logBlocks;
     if (genericLogTopics.size() == genericLogTopicFrequencies.size())
     {
       size_t i = 0;
       for (auto& topic : genericLogTopics)
       {
-        crazyflie_driver::LogBlock logBlock;
+        crazyswarm::LogBlock logBlock;
         logBlock.topic_name = topic;
         logBlock.frequency = genericLogTopicFrequencies[i];
         nl.getParam("genericLogTopic_" + topic + "_Variables", logBlock.variables);
@@ -1811,8 +1810,8 @@ private:
   }
 
   bool takeoff(
-    crazyflie_driver::Takeoff::Request& req,
-    crazyflie_driver::Takeoff::Response& res)
+    crazyswarm::Takeoff::Request& req,
+    crazyswarm::Takeoff::Response& res)
   {
     ROS_INFO("Takeoff!");
 
@@ -1827,8 +1826,8 @@ private:
   }
 
   bool land(
-    crazyflie_driver::Land::Request& req,
-    crazyflie_driver::Land::Response& res)
+    crazyswarm::Land::Request& req,
+    crazyswarm::Land::Response& res)
   {
     ROS_INFO("Land!");
 
@@ -1843,8 +1842,8 @@ private:
   }
 
   bool goTo(
-    crazyflie_driver::GoTo::Request& req,
-    crazyflie_driver::GoTo::Response& res)
+    crazyswarm::GoTo::Request& req,
+    crazyswarm::GoTo::Response& res)
   {
     ROS_INFO("GoTo!");
 
@@ -1859,8 +1858,8 @@ private:
   }
 
   bool startTrajectory(
-    crazyflie_driver::StartTrajectory::Request& req,
-    crazyflie_driver::StartTrajectory::Response& res)
+    crazyswarm::StartTrajectory::Request& req,
+    crazyswarm::StartTrajectory::Response& res)
   {
     ROS_INFO("Start trajectory!");
 
@@ -1875,8 +1874,8 @@ private:
   }
 
   bool updateParams(
-    crazyflie_driver::UpdateParams::Request& req,
-    crazyflie_driver::UpdateParams::Response& res)
+    crazyswarm::UpdateParams::Request& req,
+    crazyswarm::UpdateParams::Response& res)
   {
     ROS_INFO("UpdateParams!");
 

--- a/ros_ws/src/crazyswarm/src/crazyswarm_teleop.cpp
+++ b/ros_ws/src/crazyswarm/src/crazyswarm_teleop.cpp
@@ -7,8 +7,8 @@
 #include <sensor_msgs/Joy.h>
 #include <std_srvs/Empty.h>
 
-#include <crazyflie_driver/Takeoff.h>
-#include <crazyflie_driver/Land.h>
+#include <crazyswarm/Takeoff.h>
+#include <crazyswarm/Land.h>
 
 namespace Xbox360Buttons {
 
@@ -44,9 +44,9 @@ public:
         ros::service::waitForService("/emergency");
         m_serviceEmergency = nh.serviceClient<std_srvs::Empty>("/emergency");
         ros::service::waitForService("/takeoff");
-        m_serviceTakeoff = nh.serviceClient<crazyflie_driver::Takeoff>("/takeoff");
+        m_serviceTakeoff = nh.serviceClient<crazyswarm::Takeoff>("/takeoff");
         ros::service::waitForService("/land");
-        m_serviceLand = nh.serviceClient<crazyflie_driver::Land>("/land");
+        m_serviceLand = nh.serviceClient<crazyswarm::Land>("/land");
 
         ROS_INFO("Manager ready.");
     }
@@ -88,7 +88,7 @@ private:
 
     void takeoff()
     {
-        crazyflie_driver::Takeoff srv;
+        crazyswarm::Takeoff srv;
         srv.request.groupMask = 0;
         srv.request.height = 0.5;
         srv.request.duration = ros::Duration(2.0);
@@ -97,7 +97,7 @@ private:
 
     void land()
     {
-        crazyflie_driver::Land srv;
+        crazyswarm::Land srv;
         srv.request.groupMask = 0;
         srv.request.height = 0.05;
         srv.request.duration = ros::Duration(3.5);

--- a/ros_ws/src/crazyswarm/srv/GoTo.srv
+++ b/ros_ws/src/crazyswarm/srv/GoTo.srv
@@ -1,0 +1,6 @@
+uint8 groupMask
+bool relative
+geometry_msgs/Point goal
+float32 yaw # deg
+duration duration
+---

--- a/ros_ws/src/crazyswarm/srv/Land.srv
+++ b/ros_ws/src/crazyswarm/srv/Land.srv
@@ -1,0 +1,4 @@
+uint8 groupMask
+float32 height
+duration duration
+---

--- a/ros_ws/src/crazyswarm/srv/NotifySetpointsStop.srv
+++ b/ros_ws/src/crazyswarm/srv/NotifySetpointsStop.srv
@@ -1,0 +1,3 @@
+uint8 groupMask
+uint32 remainValidMillisecs
+---

--- a/ros_ws/src/crazyswarm/srv/SetGroupMask.srv
+++ b/ros_ws/src/crazyswarm/srv/SetGroupMask.srv
@@ -1,0 +1,2 @@
+uint8 groupMask
+---

--- a/ros_ws/src/crazyswarm/srv/StartTrajectory.srv
+++ b/ros_ws/src/crazyswarm/srv/StartTrajectory.srv
@@ -1,0 +1,6 @@
+uint8 groupMask
+uint8 trajectoryId
+float32 timescale
+bool reversed
+bool relative
+---

--- a/ros_ws/src/crazyswarm/srv/Stop.srv
+++ b/ros_ws/src/crazyswarm/srv/Stop.srv
@@ -1,0 +1,2 @@
+uint8 groupMask
+---

--- a/ros_ws/src/crazyswarm/srv/Takeoff.srv
+++ b/ros_ws/src/crazyswarm/srv/Takeoff.srv
@@ -1,0 +1,4 @@
+uint8 groupMask
+float32 height
+duration duration
+---

--- a/ros_ws/src/crazyswarm/srv/UpdateParams.srv
+++ b/ros_ws/src/crazyswarm/srv/UpdateParams.srv
@@ -1,0 +1,2 @@
+string[] params
+---

--- a/ros_ws/src/crazyswarm/srv/UploadTrajectory.srv
+++ b/ros_ws/src/crazyswarm/srv/UploadTrajectory.srv
@@ -1,0 +1,4 @@
+uint8 trajectoryId
+uint32 pieceOffset
+TrajectoryPolynomialPiece[] pieces
+---


### PR DESCRIPTION
Crazyflie_ros will be deprecated in favor of the Crazyswarm. In order
to avoid unnecessary deep dependencies, we move all the custom messages
and services directly into the Crazyswarm project.

This change also avoids to have crazyflie_cpp twice. Now, only the one
that comes with crazyflie_tools is used.