### PR TITLE
use matrices instead of rpy in VisVispy

### DIFF
--- a/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyflieSim.py
+++ b/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyflieSim.py
@@ -335,18 +335,15 @@ class Crazyflie:
     def rpy(self):
         yaw = self.yaw()
         # Unpack the matrix columns.
-        x_body, y_body, z_body = self.rot_bodytoworld().T
+        x_body, y_body, z_body = self.rotBodyToWorld().T
         pitch = math.asin(-x_body[2])
         roll = math.atan2(y_body[2], z_body[2])
         return (roll, pitch, yaw)
 
-    def rot_bodytoworld(self):
+    def rotBodyToWorld(self):
         acc = self.acceleration()
         yaw = self.yaw()
         norm = np.linalg.norm(acc)
-        # TODO: Why?
-        if norm > 5.0:
-            print("acc", acc)
         # TODO: This causes a vertical flip for faster-than-gravity vertical
         # deceleration, but fixing it would essentially require introducing the
         # idea of a controller, which we have avoided so far.

--- a/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyflieSim.py
+++ b/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyflieSim.py
@@ -333,22 +333,31 @@ class Crazyflie:
         return np.array(self.state.acc)
 
     def rpy(self):
+        yaw = self.yaw()
+        # Unpack the matrix columns.
+        x_body, y_body, z_body = self.rot_bodytoworld().T
+        pitch = math.asin(-x_body[2])
+        roll = math.atan2(y_body[2], z_body[2])
+        return (roll, pitch, yaw)
+
+    def rot_bodytoworld(self):
         acc = self.acceleration()
         yaw = self.yaw()
         norm = np.linalg.norm(acc)
+        # TODO: Why?
         if norm > 5.0:
             print("acc", acc)
-        if norm < 1e-6:
-            return (0.0, 0.0, yaw)
-        else:
-            thrust = acc + np.array([0, 0, 9.81])
-            z_body = thrust / np.linalg.norm(thrust)
-            x_world = np.array([math.cos(yaw), math.sin(yaw), 0])
-            y_body = np.cross(z_body, x_world)
-            x_body = np.cross(y_body, z_body)
-            pitch = math.asin(-x_body[2])
-            roll = math.atan2(y_body[2], z_body[2])
-            return (roll, pitch, yaw)
+        # TODO: This causes a vertical flip for faster-than-gravity vertical
+        # deceleration, but fixing it would essentially require introducing the
+        # idea of a controller, which we have avoided so far.
+        thrust = acc + np.array([0, 0, 9.81])
+        z_body = thrust / np.linalg.norm(thrust)
+        x_world = np.array([math.cos(yaw), math.sin(yaw), 0])
+        y_body = np.cross(z_body, x_world)
+        # TODO: This can have a singularity if z_body = x_world.
+        y_body /= np.linalg.norm(y_body)
+        x_body = np.cross(y_body, z_body)
+        return np.column_stack([x_body, y_body, z_body])
 
     def cmdFullState(self, pos, vel, acc, yaw, omega):
         self.mode = Crazyflie.MODE_LOW_FULLSTATE

--- a/ros_ws/src/crazyswarm/scripts/pycrazyswarm/visualizer/visVispy.py
+++ b/ros_ws/src/crazyswarm/scripts/pycrazyswarm/visualizer/visVispy.py
@@ -124,7 +124,7 @@ class VisVispy:
         positions = np.stack([cf.position() for cf in crazyflies])
 
         for i in range(0, len(self.cfs)):
-            R_state = crazyflies[i].rot_bodytoworld()
+            R_state = crazyflies[i].rotBodyToWorld()
             # Recall VisPy uses [row vector] * [matrix]!!
             T = np.eye(4)
             T[:3, :3] = np.dot(UNROT_MESHFILE_TRANSPOSE, R_state.T)

--- a/ros_ws/src/crazyswarm/scripts/test_simOnly.py
+++ b/ros_ws/src/crazyswarm/scripts/test_simOnly.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+"""Tests for simulation-only functionality."""
+
+import numpy as np
+
+from pycrazyswarm import *
+
+
+def setUp():
+    crazyflies_yaml = """
+    crazyflies:
+    - channel: 100
+      id: 1
+      initialPosition: [1.0, 0.0, 0.0]
+    """
+    swarm = Crazyswarm(crazyflies_yaml=crazyflies_yaml, args="--sim --vis null")
+    timeHelper = swarm.timeHelper
+    return swarm.allcfs, timeHelper
+
+
+def test_attitudeRPY():
+    """Checks differential flatness and roll/pitch/yaw calculations."""
+
+    end = 0.99 * np.pi  # Not trying to deal with wrapping here.
+    yaws = np.linspace(-end, end, 11)
+
+    for yaw in yaws:
+        allcfs, timeHelper = setUp()
+        cf = allcfs.crazyflies[0]
+        Z = 1.0
+
+        cf.takeoff(targetHeight=Z, duration=1.0+Z)
+        timeHelper.sleep(1.5+Z)
+        cf.goTo(np.zeros(3), yaw=yaw, duration=1.0, relative=True)
+        timeHelper.sleep(1.5)
+
+        c = np.cos(yaw)
+        s = np.sin(yaw)
+        Ryaw = np.array([
+            [c, -s, 0],
+            [s,  c, 0],
+            [0,  0, 1],
+        ])
+        forward, left, up = Ryaw.T
+
+        dirAngleSigns = [
+            ( forward, 1,  1),
+            (-forward, 1, -1),
+            (    left, 0, -1),
+            (   -left, 0,  1),
+        ]
+
+        for direction, angleIdx, sign in dirAngleSigns:
+            cf.goTo(direction, yaw=0.0, duration=1.0, relative=True)
+            timeHelper.sleep(0.25)
+            rpy = cf.rpy()
+            assert rpy[angleIdx] * sign > np.radians(20)
+            assert np.abs(rpy[1 ^ angleIdx]) < np.radians(0.001)
+            assert np.abs(rpy[2] - yaw) < np.radians(0.001)
+            timeHelper.sleep(1.0)


### PR DESCRIPTION
Bug #445 was ultimately due to VisPy's decision to use the "DirectX convention" of column-major/right-multiplying model matrices (see http://www.mindcontrol.org/~hplus/graphics/matrix-layout.html, https://github.com/vispy/vispy/issues/507).

Previously we had a `matrix -> Euler angles -> matrix` round trip because `CrazyflieSim` only exposed attitude state via the `rpy()` method, not via matrices. This was obscuring the bug so I added `rot_bodytoworld()` to help debug. Might as well keep it for clarity and efficiency.