### PR TITLE
Add dependency for nodes to messages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,5 @@ cd $ROOT
 
 # ros
 cd ros_ws
-# -k: hack for dependency issues
-catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo -k
-catkin_make
+catkin_make -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cd $ROOT

--- a/ros_ws/src/crazyswarm/CMakeLists.txt
+++ b/ros_ws/src/crazyswarm/CMakeLists.txt
@@ -173,6 +173,9 @@ endif()
 add_executable(crazyswarm_server
   src/crazyswarm_server.cpp
 )
+add_dependencies(crazyswarm_server
+  crazyswarm_gencpp
+)
 target_link_libraries(crazyswarm_server
   ${catkin_LIBRARIES}
 )
@@ -180,6 +183,9 @@ target_link_libraries(crazyswarm_server
 ## Declare a cpp executable
 add_executable(crazyswarm_teleop
   src/crazyswarm_teleop.cpp
+)
+add_dependencies(crazyswarm_teleop
+  crazyswarm_gencpp
 )
 target_link_libraries(crazyswarm_teleop
   ${catkin_LIBRARIES}


### PR DESCRIPTION
This dependency is required if the srv/msg descriptions are in the same
package, see https://answers.ros.org/question/53265/catkin-messages-and-node-in-same-package/

Fixes issue #461.