### PR TITLE
Show current pose of the Crazyflies even if no external mocap is used

### DIFF
--- a/ros_ws/src/crazyswarm/launch/hover_swarm.launch
+++ b/ros_ws/src/crazyswarm/launch/hover_swarm.launch
@@ -7,7 +7,6 @@
 
   <node pkg="crazyswarm" type="crazyswarm_server" name="crazyswarm_server" output="screen" >
     <rosparam>
-      world_frame: "/world"
       # Logging configuration (Use enable_logging to actually enable logging)
       genericLogTopics: ["log1"]
       genericLogTopicFrequencies: [10]
@@ -46,6 +45,7 @@
       force_no_cache: False
       enable_parameters: True
       enable_logging: False
+      enable_logging_pose: True
     </rosparam>
   </node>
 

--- a/ros_ws/src/crazyswarm/src/crazyswarm_server.cpp
+++ b/ros_ws/src/crazyswarm/src/crazyswarm_server.cpp
@@ -744,7 +744,7 @@ private:
     if (m_enableLoggingPose) {
       geometry_msgs::PoseStamped msg;
       msg.header.stamp = ros::Time::now();
-      msg.header.frame_id = "/world";
+      msg.header.frame_id = "world";
 
       msg.pose.position.x = data->x;
       msg.pose.position.y = data->y;
@@ -758,6 +758,12 @@ private:
       msg.pose.orientation.w = q[3];
 
       m_pubPose.publish(msg);
+
+
+      tf::Transform tftransform;
+      tftransform.setOrigin(tf::Vector3(data->x, data->y, data->z));
+      tftransform.setRotation(tf::Quaternion(q[0], q[1], q[2], q[3]));
+      m_br.sendTransform(tf::StampedTransform(tftransform, ros::Time::now(), "world", frame()));
     }
   }
 
@@ -805,6 +811,8 @@ private:
   ros::Subscriber m_subscribeCmdStop;
 
   ros::Subscriber m_subscribeCmdHover; // Hover vel subscriber
+
+  tf::TransformBroadcaster m_br;
 
   std::vector<crazyswarm::LogBlock> m_logBlocks;
   std::vector<ros::Publisher> m_pubLogDataGeneric;


### PR DESCRIPTION
In case the motioncapturetype is set to "none", logging is enabled, and
logging_pose is enabled, the current pose will be still shown in rviz.

This is in particular useful for testing with LightHouse, LPS, or flow
deck.