### PR TITLE
do not log point cloud files by default

### DIFF
--- a/ros_ws/src/crazyswarm/launch/hover_swarm.launch
+++ b/ros_ws/src/crazyswarm/launch/hover_swarm.launch
@@ -35,7 +35,7 @@
       object_tracking_type: "libobjecttracker" # one of motionCapture,libobjecttracker
       send_position_only: False # set to False to send position+orientation; set to True to send position only
       motion_capture_host_name: "vicon"
-      save_point_clouds: ~/pointCloud.ot
+      save_point_clouds: "" # set to a valid path to log mocap point cloud binary file.
       print_latency: False
       write_csvs: False
       force_no_cache: False


### PR DESCRIPTION
The point cloud log file is rarely used, so there is no reason to fill the user's storage with a potentially large file.