### PR TITLE
Docs: update dependencies for physical experiments

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -108,7 +108,7 @@ Click the appropriate tab(s) below to see the installation instructions for your
 
       3. Install the dependencies::
 
-          $ sudo apt install git swig lib${CSW_PYTHON}-dev ${CSW_PYTHON}-numpy ${CSW_PYTHON}-yaml ${CSW_PYTHON}-matplotlib ${CSW_PYTHON}-pytest ${CSW_PYTHON}-scipy gcc-arm-embedded libpcl-dev libusb-1.0-0-dev sdcc ros-[ROS version]-vrpn
+          $ sudo apt install git swig lib${CSW_PYTHON}-dev ${CSW_PYTHON}-numpy ${CSW_PYTHON}-yaml ${CSW_PYTHON}-matplotlib ${CSW_PYTHON}-pytest ${CSW_PYTHON}-scipy gcc-arm-embedded libpcl-dev libusb-1.0-0-dev ros-[ROS version]-joy
 
       4. Clone the Crazyswarm git repository::
 


### PR DESCRIPTION
* SDCC is not required anymore, since we removed the radio-firmware
* ros-[ROS version]-vrpn is not required anymore (VRPN is now a
  submodule of libmotioncapture)
* ros-[ROS version]-joy was missing, see issue #353