### PR TITLE
Generate "install dependencies" docs from CI script

### DIFF
--- a/.github/workflows/ci-ros.yml
+++ b/.github/workflows/ci-ros.yml
@@ -36,11 +36,10 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        sudo apt install -y ros-${{ matrix.ros }}-tf ros-${{ matrix.ros }}-tf-conversions
-        sudo apt install -y libpcl-dev
-        sudo apt install -y libusb-1.0-0-dev sdcc
-        sudo apt install -y swig lib${{ matrix.pyVer }}-dev ${{ matrix.pyVer }}-numpy ${{ matrix.pyVer }}-yaml ${{ matrix.pyVer }}-matplotlib ${{ matrix.pyVer }}-scipy ${{ matrix.pyVer }}-pip
-        sudo ${{ matrix.pyVer }} -m pip install pytest
+        sudo apt install -y ros-${{ matrix.ros }}-tf ros-${{ matrix.ros }}-tf-conversions ros-${{ matrix.ros }}-joy
+        sudo apt install -y libpcl-dev libusb-1.0-0-dev
+        sudo apt install -y swig lib${{ matrix.pyVer }}-dev ${{ matrix.pyVer }}-pip
+        sudo ${{ matrix.pyVer }} -m pip install pytest numpy PyYAML matplotlib scipy
 
     - name: Install Embedded GCC for Ubuntu 20
       if: matrix.os == 'ubuntu-20.04'

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,17 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
+# Generated docs.
+CSW_PYTHON ?= python3
+
+generated/full_dependencies.rstinclude: ../.github/workflows/ci-ros.yml generate_install_deps_code.py
+	$(CSW_PYTHON) $(word 2,$^) $< > $@
+
+generated/simonly_dependencies.rstinclude: generated/full_dependencies.rstinclude
+	sed -e '/ros/d' -e '/usb/d' $< > $@
+
+GENFILES: generated/full_dependencies.rstinclude generated/simonly_dependencies.rstinclude
+
 .PHONY: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -47,46 +58,47 @@ help:
 .PHONY: clean
 clean:
 	rm -rf $(BUILDDIR)/*
+	rm -rf generated/*
 
 .PHONY: html
-html:
+html: GENFILES
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 .PHONY: dirhtml
-dirhtml:
+dirhtml: GENFILES
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
 .PHONY: singlehtml
-singlehtml:
+singlehtml: GENFILES
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
 .PHONY: pickle
-pickle:
+pickle: GENFILES
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
 .PHONY: json
-json:
+json: GENFILES
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
 .PHONY: htmlhelp
-htmlhelp:
+htmlhelp: GENFILES
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
 .PHONY: qthelp
-qthelp:
+qthelp: GENFILES
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
@@ -96,7 +108,7 @@ qthelp:
 	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/Crazyswarm.qhc"
 
 .PHONY: applehelp
-applehelp:
+applehelp: GENFILES
 	$(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp
 	@echo
 	@echo "Build finished. The help book is in $(BUILDDIR)/applehelp."
@@ -105,7 +117,7 @@ applehelp:
 	      "bundle."
 
 .PHONY: devhelp
-devhelp:
+devhelp: GENFILES
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
@@ -115,19 +127,19 @@ devhelp:
 	@echo "# devhelp"
 
 .PHONY: epub
-epub:
+epub: GENFILES
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
 .PHONY: epub3
-epub3:
+epub3: GENFILES
 	$(SPHINXBUILD) -b epub3 $(ALLSPHINXOPTS) $(BUILDDIR)/epub3
 	@echo
 	@echo "Build finished. The epub3 file is in $(BUILDDIR)/epub3."
 
 .PHONY: latex
-latex:
+latex: GENFILES
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
@@ -135,33 +147,33 @@ latex:
 	      "(use \`make latexpdf' here to do that automatically)."
 
 .PHONY: latexpdf
-latexpdf:
+latexpdf: GENFILES
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
 .PHONY: latexpdfja
-latexpdfja:
+latexpdfja: GENFILES
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through platex and dvipdfmx..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
 .PHONY: text
-text:
+text: GENFILES
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
 	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
 .PHONY: man
-man:
+man: GENFILES
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 
 .PHONY: texinfo
-texinfo:
+texinfo: GENFILES
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo
 	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
@@ -169,57 +181,57 @@ texinfo:
 	      "(use \`make info' here to do that automatically)."
 
 .PHONY: info
-info:
+info: GENFILES
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
 	@echo "Running Texinfo files through makeinfo..."
 	make -C $(BUILDDIR)/texinfo info
 	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
 
 .PHONY: gettext
-gettext:
+gettext: GENFILES
 	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
 	@echo
 	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
 
 .PHONY: changes
-changes:
+changes: GENFILES
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
 .PHONY: linkcheck
-linkcheck:
+linkcheck: GENFILES
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
 .PHONY: doctest
-doctest:
+doctest: GENFILES
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
 .PHONY: coverage
-coverage:
+coverage: GENFILES
 	$(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage
 	@echo "Testing of coverage in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/coverage/python.txt."
 
 .PHONY: xml
-xml:
+xml: GENFILES
 	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml
 	@echo
 	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
 
 .PHONY: pseudoxml
-pseudoxml:
+pseudoxml: GENFILES
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
 .PHONY: dummy
-dummy:
+dummy: GENFILES
 	$(SPHINXBUILD) -b dummy $(ALLSPHINXOPTS) $(BUILDDIR)/dummy
 	@echo
 	@echo "Build finished. Dummy builder generates no files."

--- a/docs/generate_install_deps_code.py
+++ b/docs/generate_install_deps_code.py
@@ -1,0 +1,24 @@
+import sys
+
+import yaml
+
+
+def main():
+    workflow_path = sys.argv[1]
+    with open(workflow_path) as f:
+        workflow = yaml.load(f, Loader=yaml.CLoader)
+    steps = workflow["jobs"]["build"]["steps"]
+    depsteps = [s for s in steps if s["name"] == "Install Dependencies"]
+    assert len(depsteps) == 1
+    depstep = depsteps[0]
+    code = depstep["run"]
+    code = code.replace(
+        "${{ matrix.pyVer }}", "${CSW_PYTHON}"
+    ).replace(
+        "${{ matrix.ros }}", "[ROS version]"
+    )
+    print(code.strip())
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/generated/.gitignore
+++ b/docs/generated/.gitignore
@@ -1,0 +1,2 @@
+*.rst
+*.rstinclude

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -74,9 +74,10 @@ Click the appropriate tab(s) below to see the installation instructions for your
 
                 $ export CSW_PYTHON=[python2 or python3]
 
-            2. Install the dependencies::
+            2. Install the dependencies
 
-                $ sudo apt install git make gcc swig lib${CSW_PYTHON}-dev ${CSW_PYTHON}-numpy ${CSW_PYTHON}-yaml ${CSW_PYTHON}-matplotlib ${CSW_PYTHON}-pytest ${CSW_PYTHON}-scipy
+               .. include:: generated/simonly_dependencies.rstinclude
+                  :code: bash
 
             3. Clone the Crazyswarm git repository::
 
@@ -106,9 +107,10 @@ Click the appropriate tab(s) below to see the installation instructions for your
 
           $ export CSW_PYTHON=[python2 or python3]
 
-      3. Install the dependencies::
+      3. Install the dependencies
 
-          $ sudo apt install git swig lib${CSW_PYTHON}-dev ${CSW_PYTHON}-numpy ${CSW_PYTHON}-yaml ${CSW_PYTHON}-matplotlib ${CSW_PYTHON}-pytest ${CSW_PYTHON}-scipy gcc-arm-embedded libpcl-dev libusb-1.0-0-dev ros-[ROS version]-joy
+         .. include:: generated/full_dependencies.rstinclude
+            :code: bash
 
       4. Clone the Crazyswarm git repository::
 


### PR DESCRIPTION
We maintain lists of Ubuntu (and now Pip) packages for dependencies in two different places: the CI script and the docs. This creates an opportunity for them to diverge (e.g. 2c3e789a637d8c41e1a1906faaae1dd7dce1a6e4 could have also removed `sdcc` from the CI version).

In #342 we considered and rejected the idea of somehow running the CI script on the local machine. It is too complicated.

In #342 we also discussed the idea of moving the dependency install into a shell script. This is reasonable, but I prefer showing the list of installed packages in the docs for transparency.

Therefore, we instead generate the docs from the CI script in this PR.