### PR TITLE
Docs: Clarify that we support not only mocap for external tracking

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -2,6 +2,6 @@ Getting Started
 ===============
 
 #. Read the Crazyswarm paper to understand the different components of the system. A preprint is available `here <http://usc-actlab.github.io/publications/Preiss_ICRA2017.pdf>`__.
-#. Learn more about the Crazyflie platform, e.g. by reading sections 1 and 2 of "Flying Multiple UAVs Using ROS", Springer Book on Robot Operating System (ROS), 2017. A preprint is available `here <http://usc-actlab.github.io/publications/Hoenig_Springer_ROS2017.pdf>`__.
+#. Learn more about the Crazyflie platform, e.g. by reading sections 1 and 2 of "Flying Multiple UAVs Using ROS", Springer Book on Robot Operating System (ROS), 2017. A preprint is available `here <http://usc-actlab.github.io/publications/Hoenig_Springer_ROS2017.pdf>`__ or by following the `official getting started guide <https://www.bitcraze.io/documentation/start/>`__.
 #. Learn about the Robot Operating System (ROS), e.g. by reading part 1 of "Programming Robots with ROS. A Practical Introduction to the Robot Operating System" by Morgan Quigley, Brian Gerkey, William D. Smart, O'Reilly, 2015.
-#. Get to know your motion capture system (such as VICON or OptiTrack) by reading the respective user manuals.
+#. If you use a motion capture for external localization, read the respective user manual. Proper tuning of the system is essential to achieve good tracking performance.

--- a/docs/howto/git_integration.rstinclude
+++ b/docs/howto/git_integration.rstinclude
@@ -1,3 +1,5 @@
+.. _tutorial_git_integration:
+
 Crazyswarm Integration with Git
 -------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,9 +4,9 @@ Welcome to Crazyswarm's documentation!
 ======================================
 
 The Crazyswarm platform allows you to fly a swarm of
-`Bitcraze Crazyflie 2.x <https://www.bitcraze.io/products/crazyflie-2-1/>`_
+`Bitcraze Crazyflie 2.x <https://www.bitcraze.io/products/crazyflie-2-1/>`_ and `Bitcraze Crazyflie Bolt-based <https://store.bitcraze.io/products/crazyflie-bolt>`_ 
 quadcopters in tight, synchronized formations.
-A motion capture system is recommended: VICON, OptiTrack, and Qualisys are supported.
+Different localization systems are supported: LightHouse, LPS, and motion capture. The Crazyswarm is particularly optimized for motion capture systems and supports VICON, OptiTrack, and Qualisys.
 We successfully flew 49 Crazyflies using three Crazyradios.
 An example video for what you can do is shown below:
 
@@ -15,8 +15,6 @@ An example video for what you can do is shown below:
     <div style="position: relative; padding-bottom: 56.25%; margin-bottom: 20pt; height: 0; overflow: hidden; max-width: 100%; height: auto;">
         <iframe src="https://www.youtube.com/embed/D0CrjoYDt9w" frameborder="0" allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe>
     </div>
-
-It is also possible to use the Crazyflie as a control board for other quadcopter hardware.
 
 
 How is Crazyswarm different from Bitcraze's `Crazyflie Python API <https://github.com/bitcraze/crazyflie-lib-python>`_?
@@ -36,6 +34,8 @@ Here are some differences:
   Most motion capture devices do not support this natively.
   To make it possible, the user must supply the quadrotors' initial positions in a configuration file
   at startup to establish the mapping from radio addresses to positions.
+- **Broadcasts.**
+  Crazyswarm uses broadcast communication whenever possible to require fewer radios per Crazyflie. In contrast, the official SDK uses unicast communication instead.
 - **Simulation.**
   Crazyswarm has a simulation mode with 3D graphics,
   which makes it easy to validate complex scripts before running them on real hardware.


### PR DESCRIPTION
In the current documentation it remained unclear that we support LPS,
LightHouse etc. This updates the documentation throughout. The biggest
change is in configuration.rst, which required some re-ordering of
paragraphs.

Addresses issue #108.