### PR TITLE
Loosen object tracker dynamics limits

### DIFF
--- a/ros_ws/src/crazyswarm/launch/object_tracker.yaml
+++ b/ros_ws/src/crazyswarm/launch/object_tracker.yaml
@@ -23,12 +23,12 @@ markerConfigurations:
 numDynamicsConfigurations: 1
 dynamicsConfigurations:
   "0":
-    maxXVelocity: 2.0
-    maxYVelocity: 2.0
-    maxZVelocity: 2.0
-    maxPitchRate: 20.0
-    maxRollRate: 20.0
-    maxYawRate: 5.0
+    maxXVelocity: 20.0
+    maxYVelocity: 20.0
+    maxZVelocity: 20.0
+    maxPitchRate: 40.0
+    maxRollRate: 40.0
+    maxYawRate: 10.0
     maxRoll: 1.4
     maxPitch: 1.4
 numObjects: 5


### PR DESCRIPTION
The original dynamics limits for the object tracker were far too conservative, especially in translation. They should be increased for aggressive flight.

I'm not sure about the exact values here - we could do experiments if we really want to understand the feasible range of values for the Crazyflie.