### PR TITLE
Update libmotioncapture to include support for optitrack_closed_source

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -96,7 +96,10 @@ First, select your tracking system in the appropriate tab below.
       If using ``libobjecttracker`` as ``object_tracking_type`` disable all assets and make sure that labeled or unlabeled markers are being streamed.
 
       .. note::
-         If you have trouble with receiving data (e.g., when using older Motive versions), try "optitrack_closed_source" as "motion_capture_type".
+         If you have trouble with receiving data, you can try the following.
+         
+         * If your PC has multiple interfaces, set "motion_capture_interface_ip" to the IP of the interface that you want to use.
+         * If you use an older/unsupported Motive version, try setting "optitrack_closed_source" as "motion_capture_type".
 
    .. tab:: Qualisys
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -95,6 +95,9 @@ First, select your tracking system in the appropriate tab below.
 
       If using ``libobjecttracker`` as ``object_tracking_type`` disable all assets and make sure that labeled or unlabeled markers are being streamed.
 
+      .. note::
+         If you have trouble with receiving data (e.g., when using older Motive versions), try "optitrack_closed_source" as "motion_capture_type".
+
    .. tab:: Qualisys
 
       Qualisys has been tested to work with QTM 2.16 both for rigid body and point cloud. It is expected to work with any later version of QTM.

--- a/ros_ws/src/crazyswarm/CMakeLists.txt
+++ b/ros_ws/src/crazyswarm/CMakeLists.txt
@@ -2,9 +2,8 @@ cmake_minimum_required(VERSION 2.8.3)
 project(crazyswarm)
 
 
-option(BUILD_PYTHON_BINDINGS "Generate Python Bindings" OFF)
-option(BUILD_EXAMPLE "Enable Example application" OFF)
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/externalDependencies/libmotioncapture)
+option(LIBMOTIONCAPTURE_ENABLE_OPTITRACK_CLOSED_SOURCE "Enable optitrack closed source" ON)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/externalDependencies/libmotioncapture EXCLUDE_FROM_ALL)
 
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)

--- a/ros_ws/src/crazyswarm/launch/hover_swarm.launch
+++ b/ros_ws/src/crazyswarm/launch/hover_swarm.launch
@@ -31,10 +31,11 @@
         kalman:
           resetEstimation: 1
       # tracking
-      motion_capture_type: "vicon" # one of none,vicon,optitrack,qualisys,vrpn
+      motion_capture_type: "vicon" # one of none,vicon,optitrack,optitrack_closed_source,qualisys,vrpn
       object_tracking_type: "libobjecttracker" # one of motionCapture,libobjecttracker
       send_position_only: False # set to False to send position+orientation; set to True to send position only
       motion_capture_host_name: "vicon"
+      # motion_capture_interface_ip: "" # optional for optitrack with multiple interfaces
       save_point_clouds: "/dev/null" # set to a valid path to log mocap point cloud binary file.
       print_latency: False
       write_csvs: False

--- a/ros_ws/src/crazyswarm/launch/mocap_helper.launch
+++ b/ros_ws/src/crazyswarm/launch/mocap_helper.launch
@@ -4,8 +4,9 @@
   <node pkg="crazyswarm" type="mocap_helper" name="mocap_helper" output="screen" >
     <rosparam>
       # tracking
-      motion_capture_type: "vicon" # one of vicon,optitrack,qualisys,vrpn
+      motion_capture_type: "vicon" # one of vicon,optitrack,optitrack_closed_source,qualisys,vrpn
       motion_capture_host_name: "vicon"
+      # motion_capture_interface_ip: "" # optional for optitrack with multiple interfaces
     </rosparam>
   </node>
 </launch>

--- a/ros_ws/src/crazyswarm/src/crazyswarm_server.cpp
+++ b/ros_ws/src/crazyswarm/src/crazyswarm_server.cpp
@@ -1454,6 +1454,12 @@ public:
     std::string hostname;
     nl.getParam("motion_capture_host_name", hostname);
     cfg["hostname"] = hostname;
+    if (nl.hasParam("motion_capture_interface_ip")) {
+      std::string interface_ip;
+      nl.param<std::string>("motion_capture_interface_ip", interface_ip);
+      cfg["interface_ip"] = interface_ip;
+    }
+
     std::unique_ptr<libmotioncapture::MotionCapture> mocap;
 
     if (motionCaptureType != "none") {

--- a/ros_ws/src/crazyswarm/src/mocap_helper.cpp
+++ b/ros_ws/src/crazyswarm/src/mocap_helper.cpp
@@ -19,6 +19,12 @@ int main(int argc, char **argv)
   std::string hostname;
   nl.getParam("motion_capture_host_name", hostname);
   cfg["hostname"] = hostname;
+  if (nl.hasParam("motion_capture_interface_ip")) {
+    std::string interface_ip;
+    nl.param<std::string>("motion_capture_interface_ip", interface_ip);
+    cfg["interface_ip"] = interface_ip;
+  }
+
   std::unique_ptr<libmotioncapture::MotionCapture> mocap(libmotioncapture::MotionCapture::connect(motionCaptureType, cfg));
   if (!mocap) {
     throw std::runtime_error("Unknown motion capture type!");


### PR DESCRIPTION
* This also uses the EXCLUDE_FROM_ALL flag over individual flags to
  not build unnecessary targets of submodules.