### PR TITLE
clean up visualizer dependency CI/docs and video output test

### DIFF
--- a/.github/workflows/ci-ros.yml
+++ b/.github/workflows/ci-ros.yml
@@ -39,7 +39,7 @@ jobs:
         sudo apt install -y ros-${{ matrix.ros }}-tf ros-${{ matrix.ros }}-tf-conversions ros-${{ matrix.ros }}-joy
         sudo apt install -y libpcl-dev libusb-1.0-0-dev
         sudo apt install -y swig lib${{ matrix.pyVer }}-dev ${{ matrix.pyVer }}-pip
-        ${{ matrix.pyVer }} -m pip install pytest numpy PyYAML matplotlib scipy
+        ${{ matrix.pyVer }} -m pip install pytest numpy PyYAML scipy
 
     - name: Build
       run: |

--- a/conda_env.yaml
+++ b/conda_env.yaml
@@ -11,7 +11,4 @@ dependencies:
   - conda-forge::sphinx-argparse
   - conda-forge::sphinxcontrib-programoutput
   - pytest
-  - snakeviz
   - scipy
-  - ffmpeg>=4.2
-  - conda-forge::ffmpeg-python

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -80,21 +80,28 @@ Click the appropriate tab(s) below to see the installation instructions for your
                .. program-output:: python3 generate_install_deps_code.py ../.github/workflows/ci-ros.yml | sed -e '/ros/d' -e '/usb/d'
                   :shell:
 
-            3. Install the optional dependencies::
+            3. Install one or more visualizers for simulation::
+
+                (Recommended)
+                $ ${CSW_PYTHON} -m pip install vispy
+                (Alternative)
+                $ ${CSW_PYTHON} -m pip install matplotlib
+
+            4. [OPTIONAL] Install ffmpeg if you want to record high-quality videos from the simulator::
 
                 $ sudo apt install -y ffmpeg
                 $ ${CSW_PYTHON} -m pip install ffmpeg-python
 
-            4. Clone the Crazyswarm git repository::
+            5. Clone the Crazyswarm git repository::
 
                 $ git clone https://github.com/USC-ACTLab/crazyswarm.git
 
-            5. Run the build script::
+            6. Run the build script::
 
                 $ cd crazyswarm
                 $ ./buildSimOnly.sh
 
-            6. Verify the installation by running the unit tests::
+            7. Verify the installation by running the unit tests::
 
                 $ cd ros_ws/src/crazyswarm/scripts
                 $ source ../../../devel/setup.bash
@@ -119,21 +126,28 @@ Click the appropriate tab(s) below to see the installation instructions for your
          .. program-output:: python3 generate_install_deps_code.py ../.github/workflows/ci-ros.yml
             :shell:
 
-      4. Install the optional dependencies::
+      4. Install one or more visualizers for simulation::
+
+          (Recommended)
+          $ ${CSW_PYTHON} -m pip install vispy
+          (Alternative)
+          $ ${CSW_PYTHON} -m pip install matplotlib
+
+      5. [OPTIONAL] Install ffmpeg if you want to record high-quality videos from the simulator::
 
           $ sudo apt install -y ffmpeg
           $ ${CSW_PYTHON} -m pip install ffmpeg-python
 
-      5. Clone the Crazyswarm git repository::
+      6. Clone the Crazyswarm git repository::
 
           $ git clone https://github.com/USC-ACTLab/crazyswarm.git
 
-      6. Run the build script::
+      7. Run the build script::
 
           $ cd crazyswarm
           $ ./build.sh
 
-      7. Verify the installation by running the unit tests::
+      8. Verify the installation by running the unit tests::
 
           $ cd ros_ws/src/crazyswarm/scripts
           $ source ../../../devel/setup.bash

--- a/ros_ws/src/crazyswarm/scripts/test_videoOutput.py
+++ b/ros_ws/src/crazyswarm/scripts/test_videoOutput.py
@@ -42,6 +42,14 @@ DT = 1.0 / FPS
 TOTAL_TIME = 4.0
 
 
+try:
+    import vispy
+    import ffmpeg
+    HAS_DEPENDENCIES = True
+except ImportError:
+    HAS_DEPENDENCIES = False
+
+
 def videoWriterProcess(path):
     args = "--sim --vis vispy --dt {} --video {}".format(DT, path)
     swarm = Crazyswarm(crazyflies_yaml=crazyflies_yaml, args=args)
@@ -55,8 +63,7 @@ def videoWriterProcess(path):
     timeHelper.sleep(TOTAL_TIME / 2)
 
 
-@pytest.mark.skipif("TRAVIS" in os.environ or "CI" in os.environ,
-                    reason="CI usually cannot create OpenGL context.")
+@pytest.mark.skipif(not HAS_DEPENDENCIES, reason="vispy and ffmpeg required for video.")
 def test_videoOutput(tmp_path):
     # tmp_path is supplied by pytest - a directory where we can write that will
     # eventually be deleted.

--- a/ros_ws/src/crazyswarm/scripts/test_videoOutput.py
+++ b/ros_ws/src/crazyswarm/scripts/test_videoOutput.py
@@ -11,7 +11,7 @@ we must run the video-generating script in a separate process.
 
 Using `multiprocessing` would be easier, but `multiprocessing` processes don't
 run `atexit` handlers when they exit. This design is controversial [1, 2].
-Therefore, we must do a full `system()`-style process spawn witn `subprocess`
+Therefore, we must do a full `system()`-style process spawn with `subprocess`
 instead. To avoid adding another script just to support this test, this script
 will behave as the video generator process when run as `__main__()`, and behave
 as the test process when run via pytest.
@@ -46,7 +46,9 @@ try:
     import vispy
     import ffmpeg
     HAS_DEPENDENCIES = True
-except ImportError:
+# For some reason the vispy import fails in Github CI for MacOS Py2.7 with a
+# ValueError, even though we install vispy. Strange but doesn't matter.
+except (ImportError, ValueError):
     HAS_DEPENDENCIES = False
 
 


### PR DESCRIPTION
Users who run the unit tests on their machine may be surprised to see the video output test fail (#584, #620).

Due to the difficulty of getting OpenGL output on CI, we were already skipping that test conditioned on the CI sentinel environment variables. It is more direct to simply skip it if the dependencies are not installed. This will fix the user failures.

Regarding the installation docs issue in #584, we move the visualizer dependencies into a separate step. This allows us to remove all visualizers from CI.

We still keep the visualizer dependencies in the conda environment because most users will want them, but we remove `ffmpeg` because video output does not seem like a popular feature.
