### PR TITLE
change absolute file path in pycrazyswarm

### DIFF
--- a/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyswarm_py.py
+++ b/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyswarm_py.py
@@ -2,6 +2,7 @@ import argparse
 import atexit
 
 import numpy as np
+import os
 
 from . import genericJoystick
 
@@ -37,7 +38,10 @@ class Crazyswarm:
         args, unknown = parser.parse_known_args(args)
 
         if crazyflies_yaml is None:
-            crazyflies_yaml = "../launch/crazyflies.yaml"
+            folder = os.path.dirname(os.path.abspath(__file__)) # absolute path of this file
+            folder = os.path.dirname(folder) # up folder
+            folder = os.path.dirname(folder) # up folder
+            crazyflies_yaml = folder + "/launch/crazyflies.yaml"
         if crazyflies_yaml.endswith(".yaml"):
             crazyflies_yaml = open(crazyflies_yaml, 'r').read()
 


### PR DESCRIPTION
The `crazyflie.yaml` was read as a relative path in [crazyswarm_py.py](https://github.com/USC-ACTLab/crazyswarm/blob/master/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyswarm_py.py), which depends on the workspace. We have to navigate to the [`scripts`](https://github.com/USC-ACTLab/crazyswarm/tree/master/ros_ws/src/crazyswarm/scripts) folder to execute the python scripts there. If we run these python scripts in other directories, the following error will occur:
`No such file or directory: '../launch/crazyflies.yaml'`
This is because of the following codes:
https://github.com/USC-ACTLab/crazyswarm/blob/ea4a67e57743fb7c8f56270edd96b191876f4057/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyswarm_py.py#L39-L42
So I change the '../launch/crazyflies.yaml' in [crazyswarm_py.py](https://github.com/USC-ACTLab/crazyswarm/blob/master/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyswarm_py.py) into an absolute path style which uses `os.path.abspath(__file__)` to acquire the absolute path of [crazyswarm_py.py](https://github.com/USC-ACTLab/crazyswarm/blob/master/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyswarm_py.py):
```
        if crazyflies_yaml is None:
            folder = os.path.dirname(os.path.abspath(__file__)) # absolute path of this file
            folder = os.path.dirname(folder) # up folder
            folder = os.path.dirname(folder) # up folder
            crazyflies_yaml = folder + "/launch/crazyflies.yaml"
        if crazyflies_yaml.endswith(".yaml"):
            crazyflies_yaml = open(crazyflies_yaml, 'r').read()
```

This change has no conflict with original operations, and makes python scripts that depends on the pycrazyswarm to be able to execute in any directories. Even rosrun is supported. For example:
`rosrun crazyswarm cmdVelocityCircle.py`

Hope this commit can be merged. Thanks!
