### PR TITLE
Revert "change absolute file path in pycrazyswarm"

### DIFF
--- a/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyswarm_py.py
+++ b/ros_ws/src/crazyswarm/scripts/pycrazyswarm/crazyswarm_py.py
@@ -2,7 +2,6 @@ import argparse
 import atexit
 
 import numpy as np
-import os
 
 from . import genericJoystick
 
@@ -38,10 +37,7 @@ class Crazyswarm:
         args, unknown = parser.parse_known_args(args)
 
         if crazyflies_yaml is None:
-            folder = os.path.dirname(os.path.abspath(__file__)) # absolute path of this file
-            folder = os.path.dirname(folder) # up folder
-            folder = os.path.dirname(folder) # up folder
-            crazyflies_yaml = folder + "/launch/crazyflies.yaml"
+            crazyflies_yaml = "../launch/crazyflies.yaml"
         if crazyflies_yaml.endswith(".yaml"):
             crazyflies_yaml = open(crazyflies_yaml, 'r').read()
 


### PR DESCRIPTION
Reverts USC-ACTLab/crazyswarm#716
As discussed in https://github.com/USC-ACTLab/crazyswarm/pull/716#issuecomment-1355336638, the change of the absolute path of "crazyflies.yaml" may conflict with the howto instructions in https://crazyswarm.readthedocs.io/en/latest/howto/howto.html#option-2-custom-ros-package. 
Sorry that I didn't notice this problem and thanks https://github.com/USC-ACTLab/crazyswarm/pull/716#issuecomment-1355336638 for pointing it out. I would recommend reverting this change to keep consistent with the instruction document.