### PR TITLE
Logging Frequency Bug

### DIFF
--- a/ros_ws/src/crazyswarm/src/crazyswarm_server.cpp
+++ b/ros_ws/src/crazyswarm/src/crazyswarm_server.cpp
@@ -589,7 +589,7 @@ public:
           logBlock.variables,
           (void*)&m_pubLogDataGeneric[i],
           cb));
-        m_logBlocksGeneric[i]->start(logBlock.frequency / 10);
+        m_logBlocksGeneric[i]->start(100 / logBlock.frequency); // start needs a period in increments of 10ms 
         ++i;
       }
       auto end3 = std::chrono::system_clock::now();


### PR DESCRIPTION
A colleague of mine and I happened to be investigating the logging functionality of crazyflies and came across this little bug that prevents data from being logged at the intended frequency.
Example: You want to log with a frequency of 3 hz. Then we should give` m_logBlocksGeneric[i]->start()` a period of 333ms (`1000ms / 3`). Right now the calculation `3 / 10` returns 0. But, in the ` m_logBlocksGeneric[i]->start()` function there is a comment that says logging period needs to be given in increments of 10ms. Therefore we need to calculate `100 / 3`, since after that a `* 10` is applied onto that value.
Is there anything we might have missed?
Cheers!